### PR TITLE
Require user login before oAuth2 request authorization

### DIFF
--- a/htdocs/config/packages/security.yaml
+++ b/htdocs/config/packages/security.yaml
@@ -46,7 +46,7 @@ security:
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
-        - { path: ^/authorize, roles: PUBLIC_ACCESS } #OAuthBundle
+        - { path: ^/authorize, roles: IS_AUTHENTICATED_REMEMBERED } #OAuthBundle
         - { path: ^/token, role: PUBLIC_ACCESS } #OAuthBundle
         - { path: ^/login, role: PUBLIC_ACCESS }
         - { path: ^/.well-known, roles: PUBLIC_ACCESS }


### PR DESCRIPTION
See: https://github.com/thephpleague/oauth2-server-bundle/pull/196

After this, the `league/oauth2-server-bundle` can be upgraded to version `0.9` without any issue.